### PR TITLE
feat: make JWT token expiration configurable

### DIFF
--- a/Backend/delivery/main.go
+++ b/Backend/delivery/main.go
@@ -66,7 +66,7 @@ func main() {
 		log.Fatalf("Failed to initialize OTP sender: %v", err)
 	}
 	otpSenderTyped := otpSender
-	jwtService := authinfra.NewJWTService(cfg.JWTSecretKey, fmt.Sprint(cfg.JWTExpirationMinutes))
+	jwtService := authinfra.NewJWTService(cfg.JWTSecretKey, fmt.Sprint(cfg.JWTExpirationMinutes), cfg.JWTAcessTokenExpiry)
 	passwordService := authinfra.NewPasswordService()
 	authMiddleware := authinfra.NewAuthMiddleware(jwtService)
 	oauthService, err := authinfra.NewOAuth2Service(providersConfigs)

--- a/Backend/infrastructure/auth/jwt_service.go
+++ b/Backend/infrastructure/auth/jwt_service.go
@@ -13,12 +13,14 @@ import (
 type JWTService struct {
 	accessSecret 	[]byte
 	refreshSecret 	[]byte
+	accessTokenExpiry time.Duration
 }
 
-func NewJWTService(accessSecret string, refreshSecret string) svc.IJWTService {
+func NewJWTService(accessSecret string, refreshSecret string, accessTokenExpiry time.Duration) svc.IJWTService {
 	return &JWTService{
 		accessSecret: 	[]byte(accessSecret),
 		refreshSecret: 	[]byte(refreshSecret),
+		accessTokenExpiry:  accessTokenExpiry,
 	}
 }
 
@@ -27,7 +29,7 @@ func (j *JWTService) GenerateAccessToken(userID string, preferredLanguage string
 	claims := jwt.MapClaims{
 		"sub": userID,
 		"lang": preferredLanguage,
-		"exp": time.Now().Add(15 * time.Minute).Unix(),
+		"exp": time.Now().Add(j.accessTokenExpiry).Unix(),
 		"iat": time.Now().Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -35,7 +37,7 @@ func (j *JWTService) GenerateAccessToken(userID string, preferredLanguage string
 	if err != nil {
 		return "", 0, err
 	}
-	return tokenString, 15 * time.Minute, nil
+	return tokenString, j.accessTokenExpiry, nil
 }
 
 //generate verification token 

--- a/Backend/infrastructure/config/config.go
+++ b/Backend/infrastructure/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -21,6 +22,7 @@ type Config struct {
 
 	JWTSecretKey              string
 	JWTExpirationMinutes      int
+	JWTAccessTokenExpiry      time.Duration
 	RefreshTokenSecret        string
 	AccessTokenSecret         string
 	RefreshTokenExpirationMin int
@@ -108,6 +110,7 @@ func LoadConfig() (*Config, error) {
 
 		JWTSecretKey:              viper.GetString("JWT_SECRET_KEY"),
 		JWTExpirationMinutes:      viper.GetInt("JWT_EXPIRATION_MINUTES"),
+		JWTAccessTokenExpiry:       time.Duration(viper.GetInt("JWT_ACCESS_TOKEN_EXPIRY")) * time.Minute,
 		RefreshTokenSecret:        viper.GetString("REFRESH_TOKEN_SECRET"),
 		RefreshTokenExpirationMin: viper.GetInt("REFRESH_TOKEN_EXPIRATION_MINUTES"),
 


### PR DESCRIPTION
- Updated JWT service to accept configurable access token expiration
- Modified main.go to pass expiration time from configuration
- Added JWT_ACCESS_TOKEN_EXPIRY environment variable support